### PR TITLE
Mobile timestamps are logged on the previous line

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -79,6 +79,7 @@ export default class TiditPlugin extends Plugin {
 
 	getInsertPositionInLine(editor: Editor): number {
 		const cursor = editor.getCursor();
+		console.log(`Cursor at line ${cursor.line}, ch ${cursor.ch}`);
 		// line already moved with the ENTER key. look back one line
 		const lineText = editor.getLine(cursor.line - 1);
 		
@@ -155,7 +156,7 @@ export default class TiditPlugin extends Plugin {
 
 		this.addSettingTab(new TiditSettingTab(this.app, this));
 
-		this.registerDomEvent(document, "keydown", (e: KeyboardEvent) => {
+		this.registerDomEvent(document, "keyup", (e: KeyboardEvent) => {
 			if (!this.settings.tiditOn) return;
 
 			if (e.key !== "Enter") return;
@@ -177,6 +178,7 @@ export default class TiditPlugin extends Plugin {
 			}
 
 			const cursor = editor.getCursor();
+			console.log(`Cursor at line ${cursor.line}, ch ${cursor.ch}`);
 
 			const now = moment();
 			if (

--- a/main.ts
+++ b/main.ts
@@ -79,7 +79,6 @@ export default class TiditPlugin extends Plugin {
 
 	getInsertPositionInLine(editor: Editor): number {
 		const cursor = editor.getCursor();
-		console.log(`Cursor at line ${cursor.line}, ch ${cursor.ch}`);
 		// line already moved with the ENTER key. look back one line
 		const lineText = editor.getLine(cursor.line - 1);
 		
@@ -178,7 +177,6 @@ export default class TiditPlugin extends Plugin {
 			}
 
 			const cursor = editor.getCursor();
-			console.log(`Cursor at line ${cursor.line}, ch ${cursor.ch}`);
 
 			const now = moment();
 			if (


### PR DESCRIPTION
On mobile timestamps are logged on the previous line, I believe this is due to the use of the `keydown` event which seems to fire before the obsidian cursor position is updated on mobile. Desktop continues to work as normal with `keyup` event.

Before:

https://github.com/user-attachments/assets/907985fc-d763-429d-b55f-d44c81a90f26

After:

https://github.com/user-attachments/assets/4f03f7de-3bb9-4e07-b54f-c6a5e028bc34

